### PR TITLE
Updates to the ADbackend

### DIFF
--- a/Bonobo.Git.Server/Attributes/WebAuthorizeRepositoryAttribute.cs
+++ b/Bonobo.Git.Server/Attributes/WebAuthorizeRepositoryAttribute.cs
@@ -4,6 +4,7 @@ using Bonobo.Git.Server.Data;
 using Bonobo.Git.Server.Security;
 
 using Microsoft.Practices.Unity;
+using System;
 
 namespace Bonobo.Git.Server
 {
@@ -23,10 +24,8 @@ namespace Bonobo.Git.Server
 
             if (!(filterContext.Result is HttpUnauthorizedResult))
             {
-                string incomingRepoName = filterContext.Controller.ControllerContext.RouteData.Values["id"].ToString();
-                string repository = Repository.NormalizeRepositoryName(incomingRepoName, RepositoryRepository);
-
-                string user = filterContext.HttpContext.User.Username();
+                Guid incomingRepoId = Guid.Parse(filterContext.Controller.ControllerContext.RouteData.Values["id"].ToString());
+                Guid userId = filterContext.HttpContext.User.Id();
 
                 if (filterContext.HttpContext.User.IsInRole(Definitions.Roles.Administrator))
                 {
@@ -35,19 +34,19 @@ namespace Bonobo.Git.Server
 
                 if (RequiresRepositoryAdministrator)
                 {
-                    if (RepositoryPermissionService.IsRepositoryAdministrator(user, repository))
+                    if (RepositoryPermissionService.IsRepositoryAdministrator(userId, incomingRepoId))
                     {
                         return;
                     }
                 }
                 else
                 {
-                    if (RepositoryPermissionService.HasPermission(user, repository))
+                    if (RepositoryPermissionService.HasPermission(userId, incomingRepoId))
                     {
                         return;
                     }
 
-                    if (RepositoryPermissionService.AllowsAnonymous(repository))
+                    if (RepositoryPermissionService.AllowsAnonymous(incomingRepoId))
                     {
                         return;
                     }

--- a/Bonobo.Git.Server/Controllers/AccountController.cs
+++ b/Bonobo.Git.Server/Controllers/AccountController.cs
@@ -44,7 +44,7 @@ namespace Bonobo.Git.Server.Controllers
                     Name = user.GivenName,
                     Surname = user.Surname,
                     Email = user.Email,
-                    Roles = RoleProvider.GetRolesForUser(user.Name),
+                    Roles = RoleProvider.GetRolesForUser(user.Id),
                     IsReadOnly = MembershipService.IsReadOnly()
                 };
                 return View(model);
@@ -114,7 +114,7 @@ namespace Bonobo.Git.Server.Controllers
                     Surname = user.Surname,
                     Email = user.Email,
                     Roles = RoleProvider.GetAllRoles(),
-                    SelectedRoles = RoleProvider.GetRolesForUser(user.Name)
+                    SelectedRoles = RoleProvider.GetRolesForUser(user.Id)
                 };
                 return View(model);
             }
@@ -268,7 +268,7 @@ namespace Bonobo.Git.Server.Controllers
                     Name = user.GivenName,
                     Surname = user.Surname,
                     Email = user.Email,
-                    Roles = RoleProvider.GetRolesForUser(user.Name),
+                    Roles = RoleProvider.GetRolesForUser(user.Id),
                     IsReadOnly = model.IsReadOnly
                 });
             }

--- a/Bonobo.Git.Server/Controllers/GitController.cs
+++ b/Bonobo.Git.Server/Controllers/GitController.cs
@@ -23,22 +23,22 @@ namespace Bonobo.Git.Server.Controllers
         [Dependency]
         public IGitService GitService { get; set; }
 
-        public ActionResult SecureGetInfoRefs(String project, String service)
+        public ActionResult SecureGetInfoRefs(String repositoryName, String service)
         {
-            if (!RepositoryIsValid(project))
+            if (!RepositoryIsValid(repositoryName))
             {
                 return new HttpNotFoundResult();
             }
 
-            bool allowAnonClone = RepositoryPermissionService.AllowsAnonymous(project);
-            bool hasPermission = RepositoryPermissionService.HasPermission(User.Username(), project);
+            bool allowAnonClone = RepositoryPermissionService.AllowsAnonymous(repositoryName);
+            bool hasPermission = RepositoryPermissionService.HasPermission(User.Id(), repositoryName);
             bool isClone = String.Equals("git-upload-pack", service, StringComparison.OrdinalIgnoreCase);
             bool isPush = String.Equals("git-receive-pack", service, StringComparison.OrdinalIgnoreCase);
             bool allowAnonPush = UserConfiguration.Current.AllowAnonymousPush;
 
             if (hasPermission || (allowAnonClone && isClone) || (allowAnonPush && isPush))
             {
-                return GetInfoRefs(project, service);
+                return GetInfoRefs(repositoryName, service);
             }
             else
             {
@@ -47,17 +47,17 @@ namespace Bonobo.Git.Server.Controllers
         }
 
         [HttpPost]
-        public ActionResult SecureUploadPack(String project)
+        public ActionResult SecureUploadPack(String repositoryName)
         {
-            if (!RepositoryIsValid(project))
+            if (!RepositoryIsValid(repositoryName))
             {
                 return new HttpNotFoundResult();
             }
 
-            if (RepositoryPermissionService.HasPermission(User.Username(), project)
-                || RepositoryPermissionService.AllowsAnonymous(project))
+            if (RepositoryPermissionService.HasPermission(User.Id(), repositoryName)
+                || RepositoryPermissionService.AllowsAnonymous(repositoryName))
             {
-                return ExecuteUploadPack(project);
+                return ExecuteUploadPack(repositoryName);
             }
             else
             {
@@ -66,17 +66,17 @@ namespace Bonobo.Git.Server.Controllers
         }
 
         [HttpPost]
-        public ActionResult SecureReceivePack(String project)
+        public ActionResult SecureReceivePack(String repositoryName)
         {
-            if (!RepositoryIsValid(project))
+            if (!RepositoryIsValid(repositoryName))
             {
                 return new HttpNotFoundResult();
             }
 
-            if (RepositoryPermissionService.HasPermission(User.Username(), project)
-                || (RepositoryPermissionService.AllowsAnonymous(project) && UserConfiguration.Current.AllowAnonymousPush))
+            if (RepositoryPermissionService.HasPermission(User.Id(), repositoryName)
+                || (RepositoryPermissionService.AllowsAnonymous(repositoryName) && UserConfiguration.Current.AllowAnonymousPush))
             {
-                return ExecuteReceivePack(project);
+                return ExecuteReceivePack(repositoryName);
             }
             else
             {

--- a/Bonobo.Git.Server/Controllers/RepositoryController.cs
+++ b/Bonobo.Git.Server/Controllers/RepositoryController.cs
@@ -177,7 +177,7 @@ namespace Bonobo.Git.Server.Controllers
             var model = ConvertRepositoryModel(RepositoryRepository.GetRepository(id));
             if (model != null)
             {
-                model.IsCurrentUserAdministrator = User.IsInRole(Definitions.Roles.Administrator) || RepositoryPermissionService.IsRepositoryAdministrator(User.Username(), model.Name);
+                model.IsCurrentUserAdministrator = User.IsInRole(Definitions.Roles.Administrator) || RepositoryPermissionService.IsRepositoryAdministrator(User.Id(), model.Id);
                 SetGitUrls(model);
             }
             using (var browser = new RepositoryBrowser(Path.Combine(UserConfiguration.Current.Repositories, model.Name)))

--- a/Bonobo.Git.Server/Data/ADBackendStore.cs
+++ b/Bonobo.Git.Server/Data/ADBackendStore.cs
@@ -45,7 +45,7 @@ namespace Bonobo.Git.Server.Data
 
         public bool Add(T item)
         {
-            return content.TryAdd(item.Name, item) && Store(item);
+            return content.TryAdd(item.Id.ToString(), item) && Store(item);
         }
 
         public bool Remove(string key)
@@ -56,12 +56,12 @@ namespace Bonobo.Git.Server.Data
 
         public bool Remove(T item)
         {
-            return Remove(item.Name);
+            return Remove(item.Id.ToString());
         }
 
         public void Update(T item)
         {
-            if (content.TryUpdate(item.Name, item, content[item.Name]))
+            if (content.TryUpdate(item.Id.ToString(), item, content[item.Id.ToString()]))
             {
                 Store(item);
             }
@@ -69,7 +69,7 @@ namespace Bonobo.Git.Server.Data
 
         public void AddOrUpdate(T item)
         {
-            content.AddOrUpdate(item.Name, item, (k, v) => item);
+            content.AddOrUpdate(item.Id.ToString(), item, (k, v) => item);
             Store(item);
         }
 
@@ -132,7 +132,7 @@ namespace Bonobo.Git.Server.Data
                 try
                 {
                     T item = JsonConvert.DeserializeObject<T>(File.ReadAllText(filename));
-                    result.TryAdd(item.Name, item);
+                    result.TryAdd(item.Id.ToString(), item);
                 }
                 catch
                 {

--- a/Bonobo.Git.Server/Data/ADRepositoryRepository.cs
+++ b/Bonobo.Git.Server/Data/ADRepositoryRepository.cs
@@ -17,8 +17,6 @@ namespace Bonobo.Git.Server.Data
     {
         public bool Create(RepositoryModel repository)
         {
-            // To populate _id_to_name table
-            GetAllRepositories();
             repository.Id = Guid.NewGuid();
 
             return ADBackend.Instance.Repositories.Add(SanitizeModel(repository));
@@ -41,8 +39,8 @@ namespace Bonobo.Git.Server.Data
 
         public IList<RepositoryModel> GetPermittedRepositories(Guid? userId, Guid[] userTeamsId)
         {
-            return ADBackend.Instance.Repositories.Where(x => 
-                (userId != null ? false : x.Users.Count(y => y.Id == userId) > 0) ||
+            return ADBackend.Instance.Repositories.Where(x =>
+            (userId == null ? false : x.Users.Any(u => u.Id == userId.Value)) ||
                 x.Teams.Any(s => userTeamsId.Contains(userId.Value))
                 ).ToList();
         }

--- a/Bonobo.Git.Server/Data/ADTeamRepository.cs
+++ b/Bonobo.Git.Server/Data/ADTeamRepository.cs
@@ -40,9 +40,7 @@ namespace Bonobo.Git.Server.Data
 
         public TeamModel GetTeam(Guid TeamId)
         {
-            var name = _id_to_name[TeamId];
-
-            return ADBackend.Instance.Teams[name];
+            return ADBackend.Instance.Teams[TeamId.ToString()];
         }
 
         public IList<TeamModel> GetTeams(string userName)

--- a/Bonobo.Git.Server/Security/ADRepositoryPermissionService.cs
+++ b/Bonobo.Git.Server/Security/ADRepositoryPermissionService.cs
@@ -19,33 +19,47 @@ namespace Bonobo.Git.Server.Security
         public IRoleProvider RoleProvider { get; set; }
 
         [Dependency]
-        public ITeamRepository TeamRepository { get; set; }        
+        public ITeamRepository TeamRepository { get; set; }
+        
+        [Dependency]
+        public IMembershipService MemberShipService { get; set; } 
 
         public bool AllowsAnonymous(string repositoryName)
         {
             return Repository.GetRepository(repositoryName).AnonymousAccess;
         }
 
-        public bool HasPermission(string username, string repositoryName)
+        public bool AllowsAnonymous(Guid repositoryId)
+        {
+            return Repository.GetRepository(repositoryId).AnonymousAccess;
+        }
+
+        public bool HasPermission(Guid userId, string repositoryName)
+        {
+            return HasPermission(userId, Repository.GetRepository(repositoryName).Id);
+        }
+
+        public bool HasPermission(Guid userId, Guid repositoryId)
         {
             bool result = false;
 
-            RepositoryModel repositoryModel = Repository.GetRepository(repositoryName);
+            RepositoryModel repositoryModel = Repository.GetRepository(repositoryId);
+            UserModel user = MemberShipService.GetUserModel(userId);
 
-            result |= repositoryModel.Users.Select(x => x.Name).Contains(username, StringComparer.OrdinalIgnoreCase);
-            result |= repositoryModel.Administrators.Select(x => x.Name).Contains(username, StringComparer.OrdinalIgnoreCase);
-            result |= RoleProvider.GetRolesForUser(username).Contains(Definitions.Roles.Administrator);
-            result |= TeamRepository.GetTeams(username).Any(x => repositoryModel.Teams.Select(y => y.Name).Contains(x.Name, StringComparer.OrdinalIgnoreCase));
+            result |= repositoryModel.Users.Any(x => x.Id == userId);
+            result |= repositoryModel.Administrators.Any(x => x.Id == userId);
+            result |= RoleProvider.GetRolesForUser(user.Id).Contains(Definitions.Roles.Administrator);
+            result |= TeamRepository.GetTeams(userId).Any(x => repositoryModel.Teams.Select(y => y.Name).Contains(x.Name, StringComparer.OrdinalIgnoreCase));
 
             return result;
         }
 
-        public bool IsRepositoryAdministrator(string username, string repositoryName)
+        public bool IsRepositoryAdministrator(Guid userId, Guid repositoryId)
         {
             bool result = false;
 
-            result |= Repository.GetRepository(repositoryName).Administrators.Select(x => x.Name).Contains(username, StringComparer.OrdinalIgnoreCase);
-            result |= RoleProvider.GetRolesForUser(username).Contains(Definitions.Roles.Administrator);
+            result |= Repository.GetRepository(repositoryId).Administrators.Any(x => x.Id == userId);
+            result |= RoleProvider.GetRolesForUser(userId).Contains(Definitions.Roles.Administrator);
 
             return result;
         }

--- a/Bonobo.Git.Server/Security/ADRoleProvider.cs
+++ b/Bonobo.Git.Server/Security/ADRoleProvider.cs
@@ -43,9 +43,9 @@ namespace Bonobo.Git.Server.Security
             return ADBackend.Instance.Roles.Select(x => x.Name).ToArray();
         }
 
-        public string[] GetRolesForUser(string username)
+        public string[] GetRolesForUser(Guid userId)
         {
-            return ADBackend.Instance.Roles.Where(x => x.Members.Contains(username, StringComparer.OrdinalIgnoreCase)).Select(x => x.Name).ToArray();
+            return ADBackend.Instance.Roles.Where(x => x.Members.Contains(userId.ToString(), StringComparer.OrdinalIgnoreCase)).Select(x => x.Name).ToArray();
         }
 
         public string[] GetUsersInRole(string roleName)

--- a/Bonobo.Git.Server/Security/AuthenticationProvider.cs
+++ b/Bonobo.Git.Server/Security/AuthenticationProvider.cs
@@ -36,7 +36,7 @@ namespace Bonobo.Git.Server.Security
                 result.Add(new Claim(ClaimTypes.NameIdentifier, user.Name));
                 result.Add(new Claim(ClaimTypes.Email, user.Email));
                 result.Add(new Claim(ClaimTypes.Role, Definitions.Roles.Member));
-                result.AddRange(RoleProvider.GetRolesForUser(user.Name).Select(x => new Claim(ClaimTypes.Role, x)));
+                result.AddRange(RoleProvider.GetRolesForUser(user.Id).Select(x => new Claim(ClaimTypes.Role, x)));
             }
 
             return result;

--- a/Bonobo.Git.Server/Security/EFRepositoryPermissionService.cs
+++ b/Bonobo.Git.Server/Security/EFRepositoryPermissionService.cs
@@ -1,26 +1,31 @@
 ﻿using System.Linq;
 using Bonobo.Git.Server.Data;
-
+using System;
+using Microsoft.Practices.Unity;
 
 namespace Bonobo.Git.Server.Security
 {
     public class EFRepositoryPermissionService : IRepositoryPermissionService
     {
-        public bool HasPermission(string username, string project)
-        {
-            if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(project))
-                return false;
+        [Dependency]
+        public IRepositoryRepository Repository { get; set; }
 
+        public bool HasPermission(Guid userId, string repositoryName)
+        {
+            return HasPermission(userId, Repository.GetRepository(repositoryName).Id);
+        }
+
+        public bool HasPermission(Guid userId, Guid repositoryId)
+        {
             using (var database = new BonoboGitServerContext())
             {
-                username = username.ToLowerInvariant();
-                var user = database.Users.FirstOrDefault(i => i.Username == username);
-                var repository = database.Repositories.FirstOrDefault(i => i.Name == project);
+                var user = database.Users.FirstOrDefault(i => i.Id == userId);
+                var repository = database.Repositories.FirstOrDefault(i => i.Id == repositoryId);
                 if (user != null && repository != null)
                 {
                     if (user.Roles.FirstOrDefault(i => i.Name == Definitions.Roles.Administrator) != null
-                     || user.Repositories.FirstOrDefault(i => i.Name == project) != null
-                     || user.AdministratedRepositories.FirstOrDefault(i => i.Name == project) != null
+                     || user.Repositories.FirstOrDefault(i => i.Id == repositoryId) != null
+                     || user.AdministratedRepositories.FirstOrDefault(i => i.Id == repositoryId) != null
                      || user.Teams.Select(i => i.Name).FirstOrDefault(t => repository.Teams.Select(i => i.Name).Contains(t)) != null)
                     {
                         return true;
@@ -39,18 +44,25 @@ namespace Bonobo.Git.Server.Security
             }
         }
 
-        public bool IsRepositoryAdministrator(string username, string project)
+        public bool AllowsAnonymous(Guid projectId)
         {
             using (var database = new BonoboGitServerContext())
             {
-                username = username.ToLowerInvariant();
+                var isAllowsAnonymous = database.Repositories.Any(repo => repo.Id == projectId && repo.Anonymous);
+                return isAllowsAnonymous;
+            }
+        }
 
+        public bool IsRepositoryAdministrator(Guid userId, Guid projectId)
+        {
+            using (var database = new BonoboGitServerContext())
+            {
                 var isRepoAdmin =
-                    database.Users.Where(us => us.Username == username)
+                    database.Users.Where(us => us.Id == userId)
                         .Any(
                             us =>
                                 (us.Roles.Any(role => role.Name == Definitions.Roles.Administrator) ||
-                                 us.AdministratedRepositories.Any(ar => ar.Name == project)));
+                                 us.AdministratedRepositories.Any(ar => ar.Id == projectId)));
                 return isRepoAdmin;
             }
         }

--- a/Bonobo.Git.Server/Security/EFRoleProvider.cs
+++ b/Bonobo.Git.Server/Security/EFRoleProvider.cs
@@ -87,13 +87,12 @@ namespace Bonobo.Git.Server.Security
             }
         }
 
-        public string[] GetRolesForUser(string username)
+        public string[] GetRolesForUser(Guid userId)
         {
             using (var database = new BonoboGitServerContext())
             {
-                username = username.ToLowerInvariant();
                 var roles = database.Roles
-                    .Where(role => role.Users.Any(us => us.Username == username))
+                    .Where(role => role.Users.Any(us => us.Id == userId))
                     .Select(role => role.Name)
                     .ToArray();
                 return roles;

--- a/Bonobo.Git.Server/Security/IRepositoryPermissionService.cs
+++ b/Bonobo.Git.Server/Security/IRepositoryPermissionService.cs
@@ -7,8 +7,14 @@ namespace Bonobo.Git.Server.Security
 {
     public interface IRepositoryPermissionService
     {
-        bool HasPermission(string username, string project);
-        bool AllowsAnonymous(string project);
-        bool IsRepositoryAdministrator(string username, string project);
+        // Used by bonobo
+        bool HasPermission(Guid userId, Guid repositoryId);
+        bool IsRepositoryAdministrator(Guid userId, Guid repositoryId);
+        bool AllowsAnonymous(Guid repositoryId);
+
+        // Used by git clients as they don't have the GUID of the project
+        bool HasPermission(Guid userId, string repositoryName);
+        bool AllowsAnonymous(string repositoryName);
+        
     }
 }

--- a/Bonobo.Git.Server/Security/IRoleProvider.cs
+++ b/Bonobo.Git.Server/Security/IRoleProvider.cs
@@ -13,7 +13,7 @@ namespace Bonobo.Git.Server.Security
         bool DeleteRole(string roleName, bool throwOnPopulatedRole);
         string[] FindUsersInRole(string roleName, string usernameToMatch);
         string[] GetAllRoles();
-        string[] GetRolesForUser(string username);
+        string[] GetRolesForUser(Guid userId);
         string[] GetUsersInRole(string roleName);
         void RemoveUserFromRoles(string username, string[] roleNames);
         void RemoveUsersFromRoles(string[] username, string[] roleNames);


### PR DESCRIPTION
For some reason the IMembershipService is not **instanciated.**

Changed key from string to GUID in ADBackend

I think most of it is working now - but there is quite a mess with the roles as they are defined with strings. So we properly need a single method that can query the database/json file for a role by its name. But that shouldn't be complicated to do.
There is just a lot of places where we should change from string/name to guid/id. Not for it to work, but for making it more manageable in the long run.
