### PR TITLE
Added password salt column and automated test for EFMembershipService

### DIFF
--- a/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
+++ b/Bonobo.Git.Server.Test/Bonobo.Git.Server.Test.csproj
@@ -16,6 +16,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -53,7 +55,29 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.0.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.SQLite, Version=1.0.99.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Core.1.0.99.0\lib\net45\System.Data.SQLite.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Data.SQLite.EF6, Version=1.0.99.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.99.0\lib\net45\System.Data.SQLite.EF6.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Data.SQLite.Linq, Version=1.0.99.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.99.0\lib\net45\System.Data.SQLite.Linq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Mvc, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" />
   </ItemGroup>
@@ -72,6 +96,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="EFMembershipServiceTest.cs" />
     <Compile Include="MsysgitIntegrationTests.cs" />
     <Compile Include="MsysgitResources.cs" />
     <Compile Include="PathEncoderTest.cs" />
@@ -88,6 +113,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
@@ -109,6 +135,13 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.99.0\build\net45\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.99.0\build\net45\System.Data.SQLite.Core.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.99.0\build\net45\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.99.0\build\net45\System.Data.SQLite.Core.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Bonobo.Git.Server.Test/EFMembershipServiceTest.cs
+++ b/Bonobo.Git.Server.Test/EFMembershipServiceTest.cs
@@ -53,17 +53,56 @@ namespace Bonobo.Git.Server.Test
         [TestMethod]
         public void NewUserCanBeAdded()
         {
-            _service.CreateUser("testUser", "hello", "Test", "User", "test@user.com");
+            CreateTestUser();
             Assert.AreEqual(2, _service.GetAllUsers().Count);
+            var newUser = _service.GetUser("testuser");
+            Assert.AreEqual("Test", newUser.GivenName);
+            Assert.AreEqual("User", newUser.Surname);
+            Assert.AreEqual("test@user.com", newUser.Email);
         }
 
         [TestMethod]
         public void NewUserCanBeRetrieved()
         {
-            _service.CreateUser("testUser", "hello", "Test", "User", "test@user.com");
+            CreateTestUser();
             var user = _service.GetUser("testUser");
             Assert.AreEqual("testuser", user.Name);
         }
+
+        [TestMethod]
+        public void NewUserCanBeDeleted()
+        {
+            CreateTestUser();
+            Assert.AreEqual(2, _service.UserCount());
+            _service.DeleteUser("testUser");
+            Assert.AreEqual(1, _service.UserCount());
+        }
+
+        [TestMethod]
+        public void NonExistentUserDeleteIsSilentlyIgnored()
+        {
+            _service.DeleteUser("testUser");
+            Assert.AreEqual(1, _service.UserCount());
+        }
+
+        [TestMethod]
+        public void UserCanBeModified()
+        {
+            _service.UpdateUser("admin", "Mr", "Big", "big.admin@admin.com", "letmein");
+            var newUser = _service.GetUser("admin");
+            Assert.AreEqual("Mr", newUser.GivenName);
+            Assert.AreEqual("Big", newUser.Surname);
+            Assert.AreEqual("big.admin@admin.com", newUser.Email);
+            Assert.AreEqual(ValidationResult.Success, _service.ValidateUser("admin", "letmein"));
+        }
+
+
+        void CreateTestUser()
+        {
+            _service.CreateUser("testUser", "hello", "Test", "User", "test@user.com");
+        }
+
+
 
 
     }

--- a/Bonobo.Git.Server.Test/EFMembershipServiceTest.cs
+++ b/Bonobo.Git.Server.Test/EFMembershipServiceTest.cs
@@ -1,5 +1,7 @@
-﻿using System.Data.Common;
+﻿using System;
+using System.Data.Common;
 using System.Linq;
+using System.Security.Cryptography;
 using Bonobo.Git.Server.Data;
 using Bonobo.Git.Server.Data.Update;
 using Bonobo.Git.Server.Security;
@@ -17,9 +19,16 @@ namespace Bonobo.Git.Server.Test
         public void Initialize()
         {
             _connection = DbProviderFactories.GetFactory("System.Data.SQLite").CreateConnection();
-            _connection.ConnectionString = "Data Source =:memory:";
+            _connection.ConnectionString = "Data Source =:memory:;BinaryGUID=False";
             _connection.Open();
             _service = new EFMembershipService(() => new BonoboGitServerContext(_connection));
+            new AutomaticUpdater().RunWithContext(new BonoboGitServerContext(_connection));
+        }
+
+        [TestMethod]
+        public void UpdatesCanBeRunOnAlreadyUpdatedDatabase()
+        {
+            // Run all the updates again - this should be completely harmless
             new AutomaticUpdater().RunWithContext(new BonoboGitServerContext(_connection));
         }
 
@@ -45,9 +54,9 @@ namespace Bonobo.Git.Server.Test
         [TestMethod]
         public void GetUserIsCaseInsensitive()
         {
-            Assert.AreEqual("admin", _service.GetUser("admin").Name);
-            Assert.AreEqual("admin", _service.GetUser("ADMIN").Name);
-            Assert.AreEqual("admin", _service.GetUser("Admin").Name);
+            Assert.AreEqual("admin", _service.GetUserModel("admin").Name);
+            Assert.AreEqual("admin", _service.GetUserModel("ADMIN").Name);
+            Assert.AreEqual("admin", _service.GetUserModel("Admin").Name);
         }
 
         [TestMethod]
@@ -55,18 +64,36 @@ namespace Bonobo.Git.Server.Test
         {
             CreateTestUser();
             Assert.AreEqual(2, _service.GetAllUsers().Count);
-            var newUser = _service.GetUser("testuser");
+            var newUser = _service.GetUserModel("testuser");
             Assert.AreEqual("Test", newUser.GivenName);
             Assert.AreEqual("User", newUser.Surname);
             Assert.AreEqual("test@user.com", newUser.Email);
         }
 
         [TestMethod]
+        public void UserCanBeRetrievedById()
+        {
+            CreateTestUser();
+            var newUserByName = _service.GetUserModel("testuser");
+            var newUserByGuid = _service.GetUserModel(newUserByName.Id);
+
+            Assert.AreEqual(newUserByName.Name, newUserByGuid.Name);
+            Assert.AreEqual(newUserByName.Id, newUserByGuid.Id);
+        }
+
+        [TestMethod]
         public void NewUserCanBeRetrieved()
         {
             CreateTestUser();
-            var user = _service.GetUser("testUser");
+            var user = _service.GetUserModel("testUser");
             Assert.AreEqual("testuser", user.Name);
+        }
+
+        [TestMethod]
+        public void NewUsersPasswordValidates()
+        {
+            CreateTestUser();
+            Assert.AreEqual(ValidationResult.Success, _service.ValidateUser("testuseR", "hello"));
         }
 
         [TestMethod]
@@ -74,36 +101,106 @@ namespace Bonobo.Git.Server.Test
         {
             CreateTestUser();
             Assert.AreEqual(2, _service.UserCount());
-            _service.DeleteUser("testUser");
+            _service.DeleteUser(_service.GetUserModel("testUser").Id);
             Assert.AreEqual(1, _service.UserCount());
+        }
+
+        [TestMethod]
+        public void TestThatValidatingAUserWithDeprecatedHashUpgradesTheirPassword()
+        {
+            ForceInDeprecatedHash("admin", "adminpassword");
+            var startingHash = GetRawUser("admin").Password;
+            var startingSalt = GetPasswordSalt("admin");
+
+            // Validation should cause the hash to be upgraded
+            Assert.AreEqual(ValidationResult.Success, _service.ValidateUser("Admin", "adminpassword"));
+
+            // We should have different salt, and different password
+            Assert.AreNotEqual(startingSalt, GetPasswordSalt("admin"));
+            Assert.AreNotEqual(startingHash, GetRawUser("admin").Password);
+        }
+
+        [TestMethod]
+        public void TestThatFailingToValidateAUserWithDeprecatedHashDoesNotUpgradeTheirPassword()
+        {
+            ForceInDeprecatedHash("admin", "adminpassword");
+            var startingHash = GetRawUser("admin").Password;
+            var startingSalt = GetPasswordSalt("admin");
+
+            // Validation should cause the hash to be upgraded
+            Assert.AreEqual(ValidationResult.Failure, _service.ValidateUser("Admin", "adminpasswordWrong"));
+
+            // We should have different salt, and different password
+            Assert.AreEqual(startingSalt, GetPasswordSalt("admin"));
+            Assert.AreEqual(startingHash, GetRawUser("admin").Password);
+        }
+
+        // This is ignored for the moment, because I haven't enabled the forced upgrade stuff
+        [TestMethod, Ignore]
+        public void TestThatValidatingAUserWithOldStyleSaltUpgradesTheirSalt()
+        {
+            // By default, the start admin user will have old-style salt (just the username)
+            Assert.AreEqual("admin", GetPasswordSalt("admin"));
+
+            Assert.AreEqual(ValidationResult.Success, _service.ValidateUser("admin", "admin"));
+
+            // Now, the salt should have changed
+            Assert.AreNotEqual("admin", GetPasswordSalt("admin"));
         }
 
         [TestMethod]
         public void NonExistentUserDeleteIsSilentlyIgnored()
         {
-            _service.DeleteUser("testUser");
+            _service.DeleteUser(Guid.NewGuid());
             Assert.AreEqual(1, _service.UserCount());
         }
 
         [TestMethod]
         public void UserCanBeModified()
         {
-            _service.UpdateUser("admin", "Mr", "Big", "big.admin@admin.com", "letmein");
-            var newUser = _service.GetUser("admin");
+            _service.UpdateUser(_service.GetUserModel("admin").Id, "SonOfadmin", "Mr", "Big", "big.admin@admin.com", "letmein");
+            var newUser = _service.GetUserModel("sonofadmiN");
             Assert.AreEqual("Mr", newUser.GivenName);
             Assert.AreEqual("Big", newUser.Surname);
             Assert.AreEqual("big.admin@admin.com", newUser.Email);
-            Assert.AreEqual(ValidationResult.Success, _service.ValidateUser("admin", "letmein"));
+            Assert.AreEqual(ValidationResult.Success, _service.ValidateUser("sonofadmin", "letmein"));
         }
 
+        User GetRawUser(string username)
+        {
+            using (var context = new BonoboGitServerContext(_connection))
+            {
+                username = username.ToLower();
+                return context.Users.First(u => u.Username == username);
+            }
+        }
+
+        string GetPasswordSalt(string username)
+        {
+            return GetRawUser(username).PasswordSalt;
+        }
+
+        void ForceInDeprecatedHash(string username, string password)
+        {
+            using (var context = new BonoboGitServerContext(_connection))
+            {
+                username = username.ToLower();
+                var user = context.Users.First(u => u.Username == username);
+
+                using (var hashProvider = new MD5CryptoServiceProvider())
+                {
+                    var data = System.Text.Encoding.UTF8.GetBytes(password);
+                    data = hashProvider.ComputeHash(data);
+                    user.Password = BitConverter.ToString(data).Replace("-", "");
+                    user.PasswordSalt = "";
+                }
+                context.SaveChanges();
+            }
+        }
 
         void CreateTestUser()
         {
-            _service.CreateUser("testUser", "hello", "Test", "User", "test@user.com");
+            _service.CreateUser("testUser", "hello", "Test", "User", "test@user.com", null);
         }
-
-
-
-
     }
 }

--- a/Bonobo.Git.Server.Test/EFMembershipServiceTest.cs
+++ b/Bonobo.Git.Server.Test/EFMembershipServiceTest.cs
@@ -1,0 +1,70 @@
+﻿using System.Data.Common;
+using System.Linq;
+using Bonobo.Git.Server.Data;
+using Bonobo.Git.Server.Data.Update;
+using Bonobo.Git.Server.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bonobo.Git.Server.Test
+{
+    [TestClass]
+    public class EFMembershipServiceTest
+    {
+        EFMembershipService _service;
+        DbConnection _connection;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _connection = DbProviderFactories.GetFactory("System.Data.SQLite").CreateConnection();
+            _connection.ConnectionString = "Data Source =:memory:";
+            _connection.Open();
+            _service = new EFMembershipService(() => new BonoboGitServerContext(_connection));
+            new AutomaticUpdater().RunWithContext(new BonoboGitServerContext(_connection));
+        }
+
+        [TestMethod]
+        public void NewDatabaseContainsJustAdminUser()
+        {
+            var admin = _service.GetAllUsers().Single();
+            Assert.AreEqual("admin", admin.Name);
+        }
+
+        [TestMethod]
+        public void NewAdminUserHasCorrectPassword()
+        {
+            Assert.AreEqual(ValidationResult.Success, _service.ValidateUser("admin", "admin"));
+        }
+
+        [TestMethod]
+        public void PasswordsAreCaseSensitive()
+        {
+            Assert.AreEqual(ValidationResult.Failure, _service.ValidateUser("admin", "Admin"));
+        }
+
+        [TestMethod]
+        public void GetUserIsCaseInsensitive()
+        {
+            Assert.AreEqual("admin", _service.GetUser("admin").Name);
+            Assert.AreEqual("admin", _service.GetUser("ADMIN").Name);
+            Assert.AreEqual("admin", _service.GetUser("Admin").Name);
+        }
+
+        [TestMethod]
+        public void NewUserCanBeAdded()
+        {
+            _service.CreateUser("testUser", "hello", "Test", "User", "test@user.com");
+            Assert.AreEqual(2, _service.GetAllUsers().Count);
+        }
+
+        [TestMethod]
+        public void NewUserCanBeRetrieved()
+        {
+            _service.CreateUser("testUser", "hello", "Test", "User", "test@user.com");
+            var user = _service.GetUser("testUser");
+            Assert.AreEqual("testuser", user.Name);
+        }
+
+
+    }
+}

--- a/Bonobo.Git.Server.Test/PasswordServiceTest.cs
+++ b/Bonobo.Git.Server.Test/PasswordServiceTest.cs
@@ -58,7 +58,7 @@ namespace Bonobo.Git.Server.Test
             };
             var passwordService = new PasswordService(updateHook);
             bool isCorrect = passwordService
-                .ComparePassword(DefaultAdminPassword, DefaultAdminUserName, DefaultAdminHash);
+                .ComparePassword(DefaultAdminPassword, DefaultAdminUserName, DefaultAdminUserName, DefaultAdminHash);
             Assert.IsTrue(isCorrect);
         }
 
@@ -71,7 +71,7 @@ namespace Bonobo.Git.Server.Test
             };
             var passwordService = new PasswordService(updateHook);
             bool isCorrect = passwordService
-                .ComparePassword("1" + DefaultAdminPassword, DefaultAdminUserName, DefaultAdminHash);
+                .ComparePassword("1" + DefaultAdminPassword, DefaultAdminUserName, DefaultAdminUserName, DefaultAdminHash);
             Assert.IsFalse(isCorrect);
         }
 
@@ -89,7 +89,7 @@ namespace Bonobo.Git.Server.Test
             };
             var passwordService = new PasswordService(updateHook);
             bool isCorrect = passwordService
-                .ComparePassword(password, username, Md5DefaultAdminHash);
+                .ComparePassword(password, username, username, Md5DefaultAdminHash);
             Assert.IsTrue(isCorrect);
             Assert.AreEqual(1, correctUpgradeHookCalls, "Correct md5 password should be upgraded exactly once.");
         }
@@ -103,7 +103,7 @@ namespace Bonobo.Git.Server.Test
             };
             var passwordService = new PasswordService(updateHook);
             bool isCorrect = passwordService
-                .ComparePassword("1" + DefaultAdminPassword, DefaultAdminUserName, Md5DefaultAdminHash);
+                .ComparePassword("1" + DefaultAdminPassword, DefaultAdminUserName, DefaultAdminUserName, Md5DefaultAdminHash);
             Assert.IsFalse(isCorrect);
         }
     }

--- a/Bonobo.Git.Server.Test/app.config
+++ b/Bonobo.Git.Server.Test/app.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -42,6 +46,30 @@
         <assemblyIdentity name="Microsoft.IdentityModel.Protocol.Extensions" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.2.33" newVersion="1.0.2.33" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Data.SQLite" publicKeyToken="db937bc2d44ff139" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.98.0" newVersion="1.0.98.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="v12.0" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SQLite" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
+      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
+    </providers>
+  </entityFramework>
+  <system.data>
+    <DbProviderFactories>
+      <remove invariant="System.Data.SQLite.EF6" />
+      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
+      <remove invariant="System.Data.SQLite" />
+      <add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" />
+    </DbProviderFactories>
+  </system.data>
 </configuration>

--- a/Bonobo.Git.Server.Test/packages.config
+++ b/Bonobo.Git.Server.Test/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.0.0" targetFramework="net45" />
+  <package id="System.Data.SQLite" version="1.0.99.0" targetFramework="net45" />
+  <package id="System.Data.SQLite.Core" version="1.0.99.0" targetFramework="net45" />
+  <package id="System.Data.SQLite.EF6" version="1.0.99.0" targetFramework="net45" />
+  <package id="System.Data.SQLite.Linq" version="1.0.99.0" targetFramework="net45" />
+</packages>

--- a/Bonobo.Git.Server/Data/BonoboGitServerContext.cs
+++ b/Bonobo.Git.Server/Data/BonoboGitServerContext.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Bonobo.Git.Server.Data.Mapping;
 using System.Data.Entity;
 
@@ -18,6 +19,10 @@ namespace Bonobo.Git.Server.Data
 
         public BonoboGitServerContext()
             : base("Name=BonoboGitServerContext")
+        {
+        }
+
+        public BonoboGitServerContext(DbConnection databaseConnection) : base(databaseConnection, false)
         {
         }
 

--- a/Bonobo.Git.Server/Data/BonoboGitServerContext.cs
+++ b/Bonobo.Git.Server/Data/BonoboGitServerContext.cs
@@ -1,6 +1,7 @@
 using System.Data.Common;
 using Bonobo.Git.Server.Data.Mapping;
 using System.Data.Entity;
+using Microsoft.Practices.Unity;
 
 namespace Bonobo.Git.Server.Data
 {
@@ -17,6 +18,7 @@ namespace Bonobo.Git.Server.Data
             Database.SetInitializer<BonoboGitServerContext>(null);
         }
 
+        [InjectionConstructor]
         public BonoboGitServerContext()
             : base("Name=BonoboGitServerContext")
         {

--- a/Bonobo.Git.Server/Data/Mapping/UserMap.cs
+++ b/Bonobo.Git.Server/Data/Mapping/UserMap.cs
@@ -21,6 +21,7 @@ namespace Bonobo.Git.Server.Data.Mapping
             Property(t => t.Surname).HasColumnName("Surname");
             Property(t => t.Username).HasColumnName("Username");
             Property(t => t.Password).HasColumnName("Password");
+            Property(t => t.PasswordSalt).HasColumnName("PasswordSalt");
             Property(t => t.Email).HasColumnName("Email");
         }
 

--- a/Bonobo.Git.Server/Data/Update/AutomaticUpdater.cs
+++ b/Bonobo.Git.Server/Data/Update/AutomaticUpdater.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Data.Entity.Infrastructure;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Bonobo.Git.Server.Data.Update
@@ -46,11 +47,20 @@ namespace Bonobo.Git.Server.Data.Update
                         // store ecommand should be executed
                     }
                 }
-                ctxAdapter.ObjectContext.ExecuteStoreCommand(item.Command);
 
-                // the current pattern does not cut it anymore for adding the guid column
-                new AddGuidColumn(ctx);
+                try
+                {
+                    ctxAdapter.ObjectContext.ExecuteStoreCommand(item.Command);
+                }
+                catch(Exception ex)
+                {
+                    Trace.TraceError("Exception while processing upgrade script {0}\r\n{1}", item.Command, ex);
+                    throw;
+                }
             }
+            // the current pattern does not cut it anymore for adding the guid column
+            new AddGuidColumn(ctx);
+
         }
     }
 }

--- a/Bonobo.Git.Server/Data/Update/InitialCreateScript.cs
+++ b/Bonobo.Git.Server/Data/Update/InitialCreateScript.cs
@@ -38,6 +38,7 @@ namespace Bonobo.Git.Server.Data.Update
                         [Surname] VarChar(255) Not Null,
                         [Username] VarChar(255) Not Null UNIQUE,
                         [Password] VarChar(255) Not Null,
+                        [PasswordSalt] VarChar(255) Not Null,
                         [Email] VarChar(255) Not Null
                     );
 

--- a/Bonobo.Git.Server/Data/Update/InsertDefaultData.cs
+++ b/Bonobo.Git.Server/Data/Update/InsertDefaultData.cs
@@ -16,8 +16,8 @@ namespace Bonobo.Git.Server.Data.Update
                 return @"
 
                     INSERT INTO [Role] ([Id], [Name], [Description]) VALUES ('" + roleId.ToString() + @"','Administrator','System administrator');
-                    INSERT INTO [User] ([Id], [Name], [Surname], [Username], [Password], [Email]) VALUES ('"+ UserId.ToString() + @"','admin', '', 'admin', '0CC52C6751CC92916C138D8D714F003486BF8516933815DFC11D6C3E36894BFA044F97651E1F3EEBA26CDA928FB32DE0869F6ACFB787D5A33DACBA76D34473A3', '');
-                    INSERT INTO [UserRole_InRole] ([User_Id], [Role_Id]) VALUES ('"+ UserId.ToString() + "','" + roleId.ToString() + @"');
+                    INSERT INTO [User] ([Id], [Name], [Surname], [Username], [Password], [PasswordSalt], [Email]) VALUES ('"+ UserId.ToString() + @"','admin', '', 'admin', '0CC52C6751CC92916C138D8D714F003486BF8516933815DFC11D6C3E36894BFA044F97651E1F3EEBA26CDA928FB32DE0869F6ACFB787D5A33DACBA76D34473A3', 'admin', '');
+                    INSERT INTO [UserRole_InRole] ([User_Id], [Role_Id]) VALUES ('" + UserId.ToString() + "','" + roleId.ToString() + @"');
 
                     ";
             }

--- a/Bonobo.Git.Server/Data/User.cs
+++ b/Bonobo.Git.Server/Data/User.cs
@@ -16,6 +16,7 @@ namespace Bonobo.Git.Server.Data
         public string Surname { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
+        public string PasswordSalt { get; set; }
         public string Email { get; set; }
 
         public virtual ICollection<Repository> AdministratedRepositories

--- a/Bonobo.Git.Server/Global.asax.cs
+++ b/Bonobo.Git.Server/Global.asax.cs
@@ -101,7 +101,7 @@ namespace Bonobo.Git.Server
                     container.RegisterType<IRepositoryPermissionService, ADRepositoryPermissionService>();
                     break;
                 case "internal":
-                    container.RegisterType<IMembershipService, EFMembershipService>(new InjectionConstructor());
+                    container.RegisterType<IMembershipService, EFMembershipService>();
                     container.RegisterType<IRoleProvider, EFRoleProvider>();
                     container.RegisterType<ITeamRepository, EFTeamRepository>();
                     container.RegisterType<IRepositoryRepository, EFRepositoryRepository>();

--- a/Bonobo.Git.Server/Global.asax.cs
+++ b/Bonobo.Git.Server/Global.asax.cs
@@ -73,8 +73,16 @@ namespace Bonobo.Git.Server
             UserConfiguration.Initialize();
             RegisterDependencyResolver();
 
-            new AutomaticUpdater().Run();
-            new RepositorySynchronizer().Run();
+            try
+            {
+                new AutomaticUpdater().Run();
+                new RepositorySynchronizer().Run();
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine("StartupException " + ex);
+                throw;
+            }
         }
 
         private static void RegisterDependencyResolver()

--- a/Bonobo.Git.Server/Global.asax.cs
+++ b/Bonobo.Git.Server/Global.asax.cs
@@ -101,7 +101,7 @@ namespace Bonobo.Git.Server
                     container.RegisterType<IRepositoryPermissionService, ADRepositoryPermissionService>();
                     break;
                 case "internal":
-                    container.RegisterType<IMembershipService, EFMembershipService>();
+                    container.RegisterType<IMembershipService, EFMembershipService>(new InjectionConstructor());
                     container.RegisterType<IRoleProvider, EFRoleProvider>();
                     container.RegisterType<ITeamRepository, EFTeamRepository>();
                     container.RegisterType<IRepositoryRepository, EFRepositoryRepository>();

--- a/Bonobo.Git.Server/Security/EFMembershipService.cs
+++ b/Bonobo.Git.Server/Security/EFMembershipService.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography;
 using System.IO;
 using System.Text;
 using System.Data.Entity.Core;
+using System.Data.SQLite;
 
 namespace Bonobo.Git.Server.Security
 {
@@ -16,10 +17,14 @@ namespace Bonobo.Git.Server.Security
         private readonly Func<BonoboGitServerContext> _createDatabaseContext;
         private readonly IPasswordService _passwordService;
 
-        public EFMembershipService()
+        public EFMembershipService() : this(() => new BonoboGitServerContext())
+        {
+        }
+
+        public EFMembershipService(Func<BonoboGitServerContext> contextCreator)
         {
             // set up dependencies
-            _createDatabaseContext = ()=>new BonoboGitServerContext();
+            _createDatabaseContext = contextCreator;
             Action<string, string> updateUserPasswordHook =
                 (username, password)=>UpdateUser(username, null, null, null, password);
             _passwordService = new PasswordService(updateUserPasswordHook);
@@ -32,7 +37,7 @@ namespace Bonobo.Git.Server.Security
 
         public ValidationResult ValidateUser(string username, string password)
         {
-            if (String.IsNullOrEmpty(username)) throw new ArgumentException("Value cannot be null or empty.", "userName");
+            if (String.IsNullOrEmpty(username)) throw new ArgumentException("Value cannot be null or empty.", "username");
             if (String.IsNullOrEmpty(password)) throw new ArgumentException("Value cannot be null or empty.", "password");
 
             username = username.ToLowerInvariant();
@@ -45,7 +50,7 @@ namespace Bonobo.Git.Server.Security
 
         public bool CreateUser(string username, string password, string name, string surname, string email)
         {
-            if (String.IsNullOrEmpty(username)) throw new ArgumentException("Value cannot be null or empty.", "userName");
+            if (String.IsNullOrEmpty(username)) throw new ArgumentException("Value cannot be null or empty.", "username");
             if (String.IsNullOrEmpty(password)) throw new ArgumentException("Value cannot be null or empty.", "password");
             if (String.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", "name");
             if (String.IsNullOrEmpty(surname)) throw new ArgumentException("Value cannot be null or empty.", "surname");

--- a/Bonobo.Git.Server/Security/EFRoleProvider.cs
+++ b/Bonobo.Git.Server/Security/EFRoleProvider.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Web.Security;
 using Bonobo.Git.Server.Data;
 
 namespace Bonobo.Git.Server.Security

--- a/Bonobo.Git.Server/Security/IPasswordService.cs
+++ b/Bonobo.Git.Server/Security/IPasswordService.cs
@@ -3,6 +3,6 @@
     public interface IPasswordService
     {
         string GetSaltedHash(string password, string salt);
-        bool ComparePassword(string givenPassword, string knownSalt, string knownHash);
+        bool ComparePassword(string givenPassword, string userName, string knownSalt, string knownHash);
     }
 }

--- a/Bonobo.Git.Server/Security/PasswordService.cs
+++ b/Bonobo.Git.Server/Security/PasswordService.cs
@@ -33,18 +33,33 @@ namespace Bonobo.Git.Server.Security
             return GetHash(GetHash(hashedSalt + password + hashedSalt));
         }
 
-        public bool ComparePassword(string password, string salt, string hash)
+        public bool ComparePassword(string password, string username, string salt, string hash)
         {
             if (IsOfCurrentHashFormat(hash))
             {
                 return GetSaltedHash(password, salt) == hash;
+                /*
+                This is code to upgrade the salt on existing passwords, don't know if we want to do this or not
+                There's test to cover it "TestThatValidatingAUserWithOldStyleSaltUpgradesTheirSalt" which can be turned off if necessary
+                            if(GetSaltedHash(password, salt) == hash)
+                            {
+                                // We have the right password - if the salt is equal to the username, then we know we're using 
+                                // old-style salting, and this is a good chance to update it
+                                if (username == salt)
+                                {
+                                    UpdateToCurrentHashMethod(username, password);
+                                }
+                                return true;
+                            }
+
+                            return false;
+                */
             }
 
             // to not break backwards compatibility: use old and update
+            // This is the only use of username - to allow us to access accounts with deprecated hashes.  It's not used for salting any more
             if (GetDeprecatedHash(password) == hash)
             {
-                // has to be modified if we use something other than username as salt
-                var username = salt;
                 UpdateToCurrentHashMethod(username, password);
                 return true;
             }


### PR DESCRIPTION
As discussed in jakubgarfield/Bonobo-Git-Server#462 - this adds an explicit password salt column.

It also adds automated testing for the EF Membership service, and fixes some small regressions in the service which occurred during the user_id upgrade.
